### PR TITLE
Update logrus module import

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,5 +22,5 @@
 
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.0.3"

--- a/logger.go
+++ b/logger.go
@@ -3,7 +3,7 @@ package artnet
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // Fields are a representation of formatted log fields


### PR DESCRIPTION
@sirupsen, author of the [logrus](https://github.com/sirupsen/logrus) module, changed their username spelling, from `Sirupsen` to `sirupsen` which trips up the go module manager. 