### PR TITLE
Fix broken header validation when receiving a ArtPollReply packet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,26 +2,35 @@
 
 
 [[projects]]
+  digest = "1:3ac248add5bb40a3c631c5334adcd09aa72d15af2768a5bc0274084ea7b2e5ba"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:27a2a48388a50ae37f1c626bff5d63be44bca1698c2d5be40e1bbf47cfa59018"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "76eec36fa14229c4b25bb894c2d0e591527af429"
 
 [[projects]]
   branch = "master"
+  digest = "1:e9f555036bb1a2f61074131371313348581fa1b643c0e5f8c0a436bf7ce6db69"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "314a259e304ff91bd6985da2a7149bbf91237993"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6b1e5eb6523d15d8e15970007274b8b5fc722bf13c302df54bc2df97cac14ccd"
+  input-imports = ["github.com/sirupsen/logrus"]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/node.go
+++ b/node.go
@@ -213,13 +213,12 @@ func (n *Node) recvLoop() {
 	for {
 		select {
 		case payload := <-n.recvCh:
-			//if payload.err == nil {
 			p, err := packet.Unmarshal(payload.data)
-			if err == nil {
-				// if this is a valid packet we handle it
-				go n.handlePacket(p)
+			if err != nil {
+				n.log.Printf("failed to parse packet: %v", err)
+				continue
 			}
-			//}
+			go n.handlePacket(p)
 
 		case <-n.shutdownCh:
 			return

--- a/packet/header.go
+++ b/packet/header.go
@@ -54,7 +54,11 @@ func (p *Header) unmarshal(b []byte) error {
 	}
 	p.ID = [8]byte{b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]}
 	p.OpCode = code.OpCode(binary.LittleEndian.Uint16([]byte{b[8], b[9]}))
-	p.Version = [2]byte{b[10], b[11]}
+
+	if p.OpCode != code.OpPollReply {
+		p.Version = [2]byte{b[10], b[11]}
+	}
+
 	return p.validate()
 }
 
@@ -62,9 +66,14 @@ func (p *Header) validate() error {
 	if p.ID != ArtNet {
 		return errInvalidPacket
 	}
-	if p.Version[1] < version.Bytes()[1] {
+
+	// according to the protocol specification the ArtPollReply package is the only one which does NOT send the protocol
+	// version as the third information after the ID and the OpCode but insteads sends the IP (which leads to the condition
+	// to be true when the second IP octet is >= 14)
+	if p.OpCode != code.OpPollReply && p.Version[1] < version.Bytes()[1] {
 		return fmt.Errorf("incompatible version. want: =>14, got: %d", p.Version[1])
 	}
+
 	// swap endianness
 	p.OpCode = code.OpCode(swapUint16(uint16(p.OpCode)))
 	return nil

--- a/packet/header_test.go
+++ b/packet/header_test.go
@@ -1,0 +1,66 @@
+package packet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/jsimonetti/go-artnet/packet/code"
+	"github.com/jsimonetti/go-artnet/version"
+)
+
+func TestHeaderValidate(t *testing.T) {
+	v := version.Bytes()
+
+	cases := []struct {
+		pkg []byte
+		err string
+	}{
+		{pkg: makePkg(t, code.OpPoll, v[0], v[1]), err: ""},
+		{pkg: makePkg(t, code.OpPoll, v[0], 0x00), err: "incompatible version. want: =>14, got: 0"},
+		{pkg: makePkg(t, code.OpPoll, v[0], 0x0f), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "2.0.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "2.14.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "2.16.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "2.100.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "192.168.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "10.0.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "10.10.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "10.20.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "10.30.0.10")...), err: ""},
+		{pkg: makePkg(t, code.OpPollReply, ipToBytes(t, "10.30.0.10")...), err: ""},
+	}
+
+	for i, c := range cases {
+		h := Header{}
+		err := h.unmarshal(c.pkg)
+		if (err == nil && c.err != "") || (c.err == "" && err != nil) || (c.err != "" && err != nil && c.err != err.Error()) {
+			t.Errorf("case %d: Expected to get err %q, got %q", i, c.err, err)
+		}
+	}
+}
+
+func makePkg(t *testing.T, opCode code.OpCode, data ...byte) (pkg []byte) {
+	pkg = append(pkg, ArtNet[0], ArtNet[1], ArtNet[2], ArtNet[3], ArtNet[4], ArtNet[5], ArtNet[6], ArtNet[7])
+	pkg = append(pkg, opCodeToBytes(t, opCode)...)
+	pkg = append(pkg, data...)
+
+	return
+}
+
+func opCodeToBytes(t *testing.T, opCode code.OpCode) []byte {
+	buf := &bytes.Buffer{}
+	if err := binary.Write(buf, binary.LittleEndian, opCode); err != nil {
+		t.Fatalf("failed to encode opCode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func ipToBytes(t *testing.T, ipStr string) []byte {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		t.Fatalf("%q is not an IP, thanks", ipStr)
+	}
+	return []byte(ip)[12:]
+}


### PR DESCRIPTION
TLDR:

This PR fixes a bug which breaks the validation of `ArtPollReply` packages when being in a subnet with the second octet being > 14.

---
Hey Jeroen,

today I stumbled upon a nasty little bug in `go-artnet` during parsing network packages After switching my network setup. The last months (years?) I was working in a subnet of 0.255.0.0/16 due to a limitation in the router I was using, after switching the router I started using the official class a net of 2.0.0.0/8 - and out of a sudden not a single node registered at the controller. I spent several hours of debugging 1) my network setup, 2) my ArtNet nodes and 3) the code and finally found this bug, which get's dropped silently during `Node.recvLoop()`.

So the issue is the `ArtPollReply` being the only packet not having the `ProtVerHi` and `ProtVerLo` and as such the packet can't validate them, so I added an exception for that. Funnily the packet struct itself doesn't have the fields ... anyways, this bug is fixed now, please review and merge this PR.

👋 from Hamburg
Alex