### PR TITLE
Use a single connection

### DIFF
--- a/node.go
+++ b/node.go
@@ -18,7 +18,6 @@ type Node struct {
 
 	// conn is the UDP connection this node will listen on
 	conn   net.PacketConn
-	bconn  net.Conn
 	sendCh chan netPayload
 	recvCh chan netPayload
 
@@ -54,10 +53,13 @@ func NewNode(name string, style code.StyleCode, ip net.IP, log Logger) *Node {
 		shutdown: true,
 		log:      log.With(Fields{"type": "Node"}),
 	}
-	if len(ip) > 0 {
-		n.Config.IP = ip
+
+	if len(ip) < 1 {
+		// TODO: generate an IP according to spec
+		//ip = GenerateIP()
 	}
-	//n.Config.IP = GenerateIP()
+	n.Config.IP = ip
+
 	return n
 }
 
@@ -70,11 +72,6 @@ func (n *Node) Stop() {
 	if n.conn != nil {
 		if err := n.conn.Close(); err != nil {
 			n.log.Printf("failed to close read socket: %v")
-		}
-	}
-	if n.bconn != nil {
-		if err := n.bconn.Close(); err != nil {
-			n.log.Printf("failed to close write socket: %v")
 		}
 	}
 }
@@ -97,30 +94,14 @@ func (n *Node) Start() error {
 	n.shutdown = false
 
 	var err error
-	laddr := net.UDPAddr{
-		IP:   n.Config.IP,
-		Port: 0,
-		Zone: "",
-	}
-	raddr := net.UDPAddr{
-		IP:   net.ParseIP("2.255.255.255"),
-		Port: 6454,
-		Zone: "",
-	}
-	n.bconn, err = net.DialUDP("udp4", &laddr, &raddr)
-	if err != nil {
-		n.shutdownErr = fmt.Errorf("error net.DialUDP: %s", err)
-		n.log.With(Fields{"error": err}).Error("error net.DialUDP")
-		return err
-	}
-
-	n.conn, err = net.ListenPacket("udp4", "0.0.0.0:6454")
+	n.conn, err = net.ListenPacket("udp4", fmt.Sprintf(":%d", packet.ArtNetPort))
 	if err != nil {
 		n.shutdownErr = fmt.Errorf("error net.ListenPacket: %s", err)
 		n.log.With(Fields{"error": err}).Error("error net.ListenPacket")
 		return err
 	}
 
+	go n.pollReplyLoop()
 	go n.recvLoop()
 	go n.sendLoop()
 
@@ -132,6 +113,14 @@ func (n *Node) Start() error {
 func (n *Node) pollReplyLoop() {
 	var timer time.Ticker
 
+	// create an ArtPollReply packet to send out in response to an ArtPoll packet
+	p := ArtPollReplyFromConfig(n.Config)
+	me, err := p.MarshalBinary()
+	if err != nil {
+		n.log.With(Fields{"err": err}).Error("error creating ArtPollReply packet for self")
+		return
+	}
+
 	// loop until shutdown
 	for {
 		select {
@@ -139,11 +128,16 @@ func (n *Node) pollReplyLoop() {
 			// if we should regularly send replies (can be requested by the controller)
 			// we send it here
 
-		case poll := <-n.pollCh:
+		case <-n.pollCh:
 			// reply with pollReply
-			n.log.With(Fields{"poll": poll}).Debugf("poll received, now send a reply")
+			n.log.With(nil).Debug("poll received, now send a reply")
 
-			// if we are asked to send changes regularyl, set the Ticker here
+			n.sendCh <- netPayload{
+				address: broadcastAddr,
+				data:    me,
+			}
+
+			// TODO: if we are asked to send changes regularly, set the Ticker here
 
 		case <-n.shutdownCh:
 			return
@@ -164,13 +158,7 @@ func (n *Node) sendLoop() {
 				return
 			}
 
-			var num int
-			var err error
-			if payload.address.IP.Equal(broadcastAddr.IP) {
-				num, err = n.bconn.Write(payload.data)
-			} else {
-				num, err = n.conn.WriteTo(payload.data, &payload.address)
-			}
+			num, err := n.conn.WriteTo(payload.data, &payload.address)
 			if err != nil {
 				n.log.With(Fields{"error": err}).Debugf("error writing packet")
 				continue
@@ -203,13 +191,13 @@ func (n *Node) recvLoop() {
 				return
 			}
 
-			from := AddrToUDPAddr(src)
-			if n.bconn != nil && n.bconn.LocalAddr() == src {
+			if n.conn.LocalAddr() == src {
 				// this was sent by me, so we ignore it
 				//n.log.With(Fields{"src": from.String(), "bytes": num}).Debugf("ignoring received packet from self")
 				continue
 			}
 
+			from := AddrToUDPAddr(src)
 			if err != nil {
 				if err == io.EOF {
 					return
@@ -260,7 +248,7 @@ func (n *Node) handlePacket(p packet.ArtNetPacket) {
 		}
 
 	case *packet.ArtPollPacket:
-		// @todo reply to poll packets
+		n.pollCh <- *p
 
 	default:
 		n.log.With(Fields{"packet": p}).Debugf("unknown packet type")

--- a/node.go
+++ b/node.go
@@ -136,7 +136,7 @@ func (n *Node) pollReplyLoop() {
 
 		case <-n.pollCh:
 			// reply with pollReply
-			n.log.With(nil).Debug("poll received, now send a reply")
+			n.log.With(nil).Debug("sending ArtPollReply")
 
 			n.sendCh <- netPayload{
 				address: broadcastAddr,


### PR DESCRIPTION
We used double network connections for sending and receiving.
This resulted in the source port of broadcast packets to use a random port.
Using this method we have just a single connection to take care of.

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>