### PR TITLE
Fix OpCode reading on node packet callback handling

### DIFF
--- a/node.go
+++ b/node.go
@@ -1,7 +1,6 @@
 package artnet
 
 import (
-	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -247,7 +246,7 @@ func (n *Node) recvLoop() {
 			// opcode which we can now extract and handle
 			// the packet by calling the corresponding
 			// callback
-			go n.handlePacket(p, code.OpCode(binary.BigEndian.Uint16([]byte{payload.data[8], payload.data[9]})))
+			go n.handlePacket(p)
 
 		case <-n.shutdownCh:
 			return
@@ -256,8 +255,8 @@ func (n *Node) recvLoop() {
 }
 
 // handlePacket contains the logic for dealing with incoming packets
-func (n *Node) handlePacket(p packet.ArtNetPacket, opCode code.OpCode) {
-	callback, ok := n.callbacks[opCode]
+func (n *Node) handlePacket(p packet.ArtNetPacket) {
+	callback, ok := n.callbacks[p.GetOpCode()]
 	if !ok {
 		n.log.With(Fields{"packet": p}).Debugf("ignoring unhandled packet")
 		return

--- a/packet/artpollreply.go
+++ b/packet/artpollreply.go
@@ -139,6 +139,11 @@ func NewArtPollReplyPacket() *ArtPollReplyPacket {
 	return &ArtPollReplyPacket{}
 }
 
+// GetOpCode returns the OpCode parsed by validate method
+func (p *ArtPollReplyPacket) GetOpCode() code.OpCode {
+	return p.OpCode
+}
+
 // MarshalBinary marshals an ArtPollReplyPacket into a byte slice.
 func (p *ArtPollReplyPacket) MarshalBinary() ([]byte, error) {
 	return marshalPacket(p)

--- a/packet/header.go
+++ b/packet/header.go
@@ -26,6 +26,7 @@ type ArtNetPacket interface {
 	encoding.BinaryUnmarshaler
 	validate() error
 	finish()
+	GetOpCode() code.OpCode
 }
 
 // ArtNet is the fixed string "Art-Net" terminated with a zero
@@ -46,6 +47,11 @@ type Header struct {
 
 	// Version of this packet
 	Version [2]byte
+}
+
+// GetOpCode returns the OpCode parsed by validate method
+func (p *Header) GetOpCode() code.OpCode {
+	return p.OpCode
 }
 
 func (p *Header) unmarshal(b []byte) error {


### PR DESCRIPTION
In jsimonetti/go-artnet#18 @h3ndrk introduced node OpCode callbacks, but unfortunatelly this broke the only packet which behaves completely different, which is ArtPollReply. And thus broke the controller logic.

I decided to add a method to the ArtNetPacket interface because we already have the (well tested) logic of decoding the OpCode inside of the packets validate method.