### PR TITLE
Add option to change broadcast address

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,5 +1,7 @@
 package artnet
 
+import "net"
+
 // Option is a functional option handler for Controller.
 type Option func(*Controller) error
 
@@ -12,6 +14,30 @@ func (c *Controller) SetOption(option Option) error {
 func MaxFPS(fps int) Option {
 	return func(c *Controller) error {
 		c.maxFPS = fps
+		return nil
+	}
+}
+
+// BroadcastAddr sets the broadcast address to use; defaults to 2.255.255.255:6454
+func BroadcastAddr(addr net.UDPAddr) Option {
+	return func(c *Controller) error {
+		c.broadcastAddr = addr
+		return nil
+	}
+}
+
+// NodeOption is a functional option handler for Node.
+type NodeOption func(*Node) error
+
+// SetOption runs a functional option against Node.
+func (n *Node) SetOption(option NodeOption) error {
+	return option(n)
+}
+
+// NodeBroadcastAddress sets the broadcast address to use; defaults to 2.255.255.255:6454
+func NodeBroadcastAddress(addr net.UDPAddr) NodeOption {
+	return func(n *Node) error {
+		n.broadcastAddr = addr
 		return nil
 	}
 }


### PR DESCRIPTION
This gives the caller the option to change the broadcast address. This is useful when artnet gear, like a WLED controller, is on a different network than the "standard" 2.x.x.x network. This should maintain backwards compatibility. 