### PR TITLE
Reception of unknown packet types no longer leads to a crash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/72nd/go-artnet
+module github.com/jsimonetti/go-artnet
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsimonetti/go-artnet
+module github.com/72nd/go-artnet
 
 go 1.13
 

--- a/packet/header.go
+++ b/packet/header.go
@@ -18,6 +18,7 @@ var (
 	errInvalidPacket         = errors.New("invalid Art-Net packet")
 	errInvalidOpCode         = errors.New("invalid OpCode in packet")
 	errInvalidStyleCode      = errors.New("invalid StyleCode in packet")
+	errNotImplementedOpCode  = errors.New("not implemented OpCode in packet")
 )
 
 // ArtNetPacket is the interface used for passing around different kinds of ArtNet packets.

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -14,6 +14,8 @@ func Unmarshal(b []byte) (p ArtNetPacket, err error) {
 		return
 	}
 
+	notImplErr := fmt.Errorf("unimplemented opcode %#v found", h.OpCode)
+
 	switch h.OpCode {
 	case code.OpPoll:
 		p = &ArtPollPacket{}
@@ -33,38 +35,61 @@ func Unmarshal(b []byte) (p ArtNetPacket, err error) {
 	case code.OpAddress:
 		p = &ArtAddressPacket{}
 	case code.OpInput:
+		return nil, notImplErr
 	case code.OpTodRequest:
+		return nil, notImplErr
 	case code.OpTodData:
+		return nil, notImplErr
 	case code.OpTodControl:
+		return nil, notImplErr
 	case code.OpRdm:
+		return nil, notImplErr
 	case code.OpRdmSub:
+		return nil, notImplErr
 	case code.OpMedia:
+		return nil, notImplErr
 	case code.OpMediaPatch:
+		return nil, notImplErr
 	case code.OpMediaControl:
+		return nil, notImplErr
 	case code.OpMediaContrlReply:
+		return nil, notImplErr
 	case code.OpTimeCode:
 		p = &ArtTimeCodePacket{}
 	case code.OpTimeSync:
+		return nil, notImplErr
 	case code.OpTrigger:
 		p = &ArtTriggerPacket{}
 	case code.OpDirectory:
+		return nil, notImplErr
 	case code.OpDirectoryReply:
+		return nil, notImplErr
 	case code.OpVideoSetup:
+		return nil, notImplErr
 	case code.OpVideoPalette:
+		return nil, notImplErr
 	case code.OpVideoData:
+		return nil, notImplErr
 	case code.OpMacMaster:
+		return nil, notImplErr
 	case code.OpMacSlave:
+		return nil, notImplErr
 	case code.OpFirmwareMaster:
+		return nil, notImplErr
 	case code.OpFirmwareReply:
+		return nil, notImplErr
 	case code.OpFileTnMaster:
+		return nil, notImplErr
 	case code.OpFileFnMaster:
+		return nil, notImplErr
 	case code.OpFileFnReply:
+		return nil, notImplErr
 	case code.OpIPProg:
 		p = &ArtIPProgPacket{}
 	case code.OpIPProgReply:
 		p = &ArtIPProgReplyPacket{}
 	default:
-		return nil, fmt.Errorf("unimplemented opcode %#v found", h.OpCode)
+		return nil, notImplErr
 	}
 
 	err = p.UnmarshalBinary(b)

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -36,58 +36,38 @@ func Unmarshal(b []byte) (p ArtNetPacket, err error) {
 		p = &ArtAddressPacket{}
 	case code.OpInput:
 		return nil, notImplErr
-	case code.OpTodRequest:
-		return nil, notImplErr
-	case code.OpTodData:
-		return nil, notImplErr
-	case code.OpTodControl:
-		return nil, notImplErr
-	case code.OpRdm:
-		return nil, notImplErr
-	case code.OpRdmSub:
-		return nil, notImplErr
-	case code.OpMedia:
-		return nil, notImplErr
-	case code.OpMediaPatch:
-		return nil, notImplErr
-	case code.OpMediaControl:
-		return nil, notImplErr
-	case code.OpMediaContrlReply:
-		return nil, notImplErr
 	case code.OpTimeCode:
 		p = &ArtTimeCodePacket{}
-	case code.OpTimeSync:
-		return nil, notImplErr
 	case code.OpTrigger:
 		p = &ArtTriggerPacket{}
-	case code.OpDirectory:
-		return nil, notImplErr
-	case code.OpDirectoryReply:
-		return nil, notImplErr
-	case code.OpVideoSetup:
-		return nil, notImplErr
-	case code.OpVideoPalette:
-		return nil, notImplErr
-	case code.OpVideoData:
-		return nil, notImplErr
-	case code.OpMacMaster:
-		return nil, notImplErr
-	case code.OpMacSlave:
-		return nil, notImplErr
-	case code.OpFirmwareMaster:
-		return nil, notImplErr
-	case code.OpFirmwareReply:
-		return nil, notImplErr
-	case code.OpFileTnMaster:
-		return nil, notImplErr
-	case code.OpFileFnMaster:
-		return nil, notImplErr
-	case code.OpFileFnReply:
-		return nil, notImplErr
 	case code.OpIPProg:
 		p = &ArtIPProgPacket{}
 	case code.OpIPProgReply:
 		p = &ArtIPProgReplyPacket{}
+	case
+		code.OpDirectory,
+		code.OpDirectoryReply,
+		code.OpFileFnMaster,
+		code.OpFileFnReply,
+		code.OpFileTnMaster,
+		code.OpFirmwareMaster,
+		code.OpFirmwareReply,
+		code.OpMacMaster,
+		code.OpMacSlave,
+		code.OpMedia,
+		code.OpMediaContrlReply,
+		code.OpMediaControl,
+		code.OpMediaPatch,
+		code.OpRdm,
+		code.OpRdmSub,
+		code.OpTimeSync,
+		code.OpTodControl,
+		code.OpTodData,
+		code.OpVideoData,
+		code.OpVideoPalette,
+		code.OpVideoSetup,
+		code.OpTodRequest:
+		return nil, notImplErr
 	default:
 		return nil, notImplErr
 	}

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -67,9 +67,9 @@ func Unmarshal(b []byte) (p ArtNetPacket, err error) {
 		code.OpVideoPalette,
 		code.OpVideoSetup,
 		code.OpTodRequest:
-		return nil, notImplErr
+		return nil, fmt.Errorf("%w %#v", errNotImplementedOpCode, h.OpCode)
 	default:
-		return nil, notImplErr
+		return nil, fmt.Errorf("%w %#v", errInvalidOpCode, h.OpCode)
 	}
 
 	err = p.UnmarshalBinary(b)


### PR DESCRIPTION
Currently, receiving an unimplemented packet type causes the application to crash. This pull request means that the unmarshall method in packet.go now correctly returns an error if the packet is not yet implemented by the library.