### PR TITLE
Partial implementation of the port info for ArtPollReply

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,6 +79,7 @@ func ArtPollReplyFromConfig(c NodeConfig) *packet.ArtPollReplyPacket {
 		NetSwitch:   c.BaseAddress.Net,
 		SubSwitch:   c.BaseAddress.SubUni,
 		NumPorts:    c.NumberOfPorts(),
+		PortTypes:   c.PortTypes(),
 	}
 
 	copy(p.IPAddress[0:4], c.IP.To4())
@@ -101,15 +102,32 @@ func (c NodeConfig) NumberOfPorts() uint16 {
 }
 
 // validate will check the config and return an error if something is not valid.
-// This method is needed as currently only for in- and/or output ports can be
-// announced on the Art-Net network but the user can define an arbitrary number of
-// InputPorts and/or OutputPorts.
+// The main objective of this method is to check if the in- and output-ports configured
+// by the user can be announced on the Art-Net network. It checks:
+//
+//   - At max 4 in- and/or outputs are supported per node.
+//   - If a port supports in- and output at the same time the protocol type has to be
+//     the same for the input port of the same index as the output port.
 func (c NodeConfig) validate() error {
 	if len(c.InputPorts) > 4 {
 		return fmt.Errorf("validation error: more than 4 input ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
 	}
 	if len(c.OutputPorts) > 4 {
 		return fmt.Errorf("validation error: more than 4 output ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
+	}
+	for i := 0; i < 4; i++ {
+		if len(c.InputPorts) < i || len(c.OutputPorts) < i {
+			continue
+		}
+		if c.InputPorts[i].Type.Type() != c.OutputPorts[i].Type.Type() {
+			return fmt.Errorf(
+				"validation error: the type (%s) of input port %d has a different type (%s) than output port %d, input and output ports with the same index must have the same type",
+				c.InputPorts[i].Type.Type(),
+				i+1,
+				c.OutputPorts[i].Type.Type(),
+				i+1,
+			)
+		}
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -97,10 +97,10 @@ func ArtPollReplyFromConfig(c NodeConfig) *packet.ArtPollReplyPacket {
 // InputPorts and/or OutputPorts.
 func (c NodeConfig) validate() error {
 	if len(c.InputPorts) > 4 {
-		return fmt.Errorf("more than 4 input ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
+		return fmt.Errorf("validation error: more than 4 input ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
 	}
 	if len(c.OutputPorts) > 4 {
-		return fmt.Errorf("more than 4 output ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
+		return fmt.Errorf("validation error: more than 4 output ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -91,6 +91,20 @@ func ArtPollReplyFromConfig(c NodeConfig) *packet.ArtPollReplyPacket {
 	return p
 }
 
+// validate will check the config and return an error if something is not valid.
+// This method is needed as currently only for in- and/or output ports can be
+// announced on the Art-Net network but the user can define an arbitrary number of
+// InputPorts and/or OutputPorts.
+func (c NodeConfig) validate() error {
+	if len(c.InputPorts) > 4 {
+		return fmt.Errorf("more than 4 input ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
+	}
+	if len(c.OutputPorts) > 4 {
+		return fmt.Errorf("more than 4 output ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
+	}
+	return nil
+}
+
 // ConfigFromArtPollReply will return a Config from the information in the ArtPollReplyPacket
 func ConfigFromArtPollReply(p packet.ArtPollReplyPacket) NodeConfig {
 	nodeConfig := NodeConfig{

--- a/config.go
+++ b/config.go
@@ -78,6 +78,7 @@ func ArtPollReplyFromConfig(c NodeConfig) *packet.ArtPollReplyPacket {
 		Status2:     c.Status2,
 		NetSwitch:   c.BaseAddress.Net,
 		SubSwitch:   c.BaseAddress.SubUni,
+		NumPorts:    c.NumberOfPorts(),
 	}
 
 	copy(p.IPAddress[0:4], c.IP.To4())
@@ -89,6 +90,14 @@ func ArtPollReplyFromConfig(c NodeConfig) *packet.ArtPollReplyPacket {
 	copy(p.Macaddress[0:6], c.Ethernet)
 
 	return p
+}
+
+// NumberOfPorts returns the count of node ports.
+func (c NodeConfig) NumberOfPorts() uint16 {
+	if len(c.InputPorts) > len(c.OutputPorts) {
+		return uint16(len(c.InputPorts))
+	}
+	return uint16(len(c.OutputPorts))
 }
 
 // validate will check the config and return an error if something is not valid.

--- a/config.go
+++ b/config.go
@@ -93,12 +93,31 @@ func ArtPollReplyFromConfig(c NodeConfig) *packet.ArtPollReplyPacket {
 	return p
 }
 
-// NumberOfPorts returns the count of node ports.
+// NumberOfPorts returns the count of node ports. This method assumes that
+// NodeConfig is validated.
 func (c NodeConfig) NumberOfPorts() uint16 {
 	if len(c.InputPorts) > len(c.OutputPorts) {
 		return uint16(len(c.InputPorts))
 	}
 	return uint16(len(c.OutputPorts))
+}
+
+// PortType merges the InputPorts and OutputPorts config into a single PortTypes
+// definition. This method assumes that NodeConfig is validated.
+func (c NodeConfig) PortTypes() [4]code.PortType {
+	rsl := [4]code.PortType{}
+	for i := 0; i < 4; i++ {
+		tmp := code.PortType(0)
+		if len(c.InputPorts) > i {
+			tmp = tmp.WithInput(true)
+			rsl[i] = tmp.WithType(c.InputPorts[i].Type.Type())
+		}
+		if len(c.OutputPorts) > i {
+			tmp = tmp.WithOutput(true)
+			rsl[i] = tmp.WithType(c.OutputPorts[i].Type.Type())
+		}
+	}
+	return rsl
 }
 
 // validate will check the config and return an error if something is not valid.

--- a/config.go
+++ b/config.go
@@ -135,7 +135,7 @@ func (c NodeConfig) validate() error {
 		return fmt.Errorf("validation error: more than 4 output ports configured (%d) for the node, this isn't supported by the library", len(c.InputPorts))
 	}
 	for i := 0; i < 4; i++ {
-		if len(c.InputPorts) < i || len(c.OutputPorts) < i {
+		if len(c.InputPorts) <= i || len(c.OutputPorts) <= i {
 			continue
 		}
 		if c.InputPorts[i].Type.Type() != c.OutputPorts[i].Type.Type() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/72nd/go-artnet
+module github.com/jsimonetti/go-artnet
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsimonetti/go-artnet
+module github.com/72nd/go-artnet
 
 go 1.13
 

--- a/node.go
+++ b/node.go
@@ -108,6 +108,9 @@ func (n *Node) isShutdown() bool {
 
 // Start will start the controller
 func (n *Node) Start() error {
+	if err := n.Config.validate(); err != nil {
+		return err
+	}
 	n.log.With(Fields{"ip": n.Config.IP.String(), "type": n.Config.Type.String()}).Debug("node started")
 
 	n.sendCh = make(chan netPayload, 10)


### PR DESCRIPTION
The control software I use only sends Art-Net data to a node if it contains the port info. This pull request causes the ArtPollReply to specify the correct number and type of ports. The input/output status is still not declared correctly.

A single ArtPollReply can declare a maximum of four node ports (otherwise several ArtPollReplys would have to be sent one after the other, which this patch does not implement). A validation method therefore checks at node.Start() whether the configuration (number of ports and matching types) is permissible at all.