### PR TITLE
Adds an option to change the listen-on address and exposes the UDP connection

### DIFF
--- a/node.go
+++ b/node.go
@@ -22,10 +22,11 @@ type Node struct {
 	broadcastAddr net.UDPAddr
 
 	// conn is the UDP connection this node will listen on
-	conn      *net.UDPConn
-	localAddr net.UDPAddr
-	sendCh    chan netPayload
-	recvCh    chan netPayload
+	conn       *net.UDPConn
+	localAddr  net.UDPAddr
+	listenAddr net.UDPAddr
+	sendCh     chan netPayload
+	recvCh     chan netPayload
 
 	// shutdownCh will be closed on shutdown of the node
 	shutdownCh   chan struct{}
@@ -57,6 +58,7 @@ func NewNode(name string, style code.StyleCode, ip net.IP, log Logger, opts ...N
 			Name: name,
 			Type: style,
 		},
+		listenAddr:    net.UDPAddr{Port: packet.ArtNetPort},
 		broadcastAddr: defaultBroadcastAddr,
 		conn:          nil,
 		shutdown:      true,
@@ -121,7 +123,7 @@ func (n *Node) Start() error {
 	n.shutdownCh = make(chan struct{})
 	n.shutdown = false
 
-	c, err := net.ListenPacket("udp4", fmt.Sprintf(":%d", packet.ArtNetPort))
+	c, err := net.ListenPacket("udp4", n.listenAddr.String())
 	if err != nil {
 		n.shutdownErr = fmt.Errorf("error net.ListenPacket: %s", err)
 		n.log.With(Fields{"error": err}).Error("error net.ListenPacket")

--- a/node.go
+++ b/node.go
@@ -87,6 +87,10 @@ func NewNode(name string, style code.StyleCode, ip net.IP, log Logger, opts ...N
 	return n
 }
 
+func (n *Node) Connection() *net.UDPConn {
+	return n.conn
+}
+
 // Stop will stop all running routines and close the network connection
 func (n *Node) Stop() {
 	n.shutdownLock.Lock()

--- a/node.go
+++ b/node.go
@@ -69,10 +69,6 @@ func NewNode(name string, style code.StyleCode, ip net.IP, log Logger, opts ...N
 		n.SetOption(opt)
 	}
 
-	for _, opt := range opts {
-		n.SetOption(opt)
-	}
-
 	// initialize required node callbacks
 	n.callbacks = map[code.OpCode]NodeCallbackFn{
 		code.OpPoll:      n.handlePacketPoll,

--- a/node.go
+++ b/node.go
@@ -22,10 +22,11 @@ type Node struct {
 	broadcastAddr net.UDPAddr
 
 	// conn is the UDP connection this node will listen on
-	conn      *net.UDPConn
-	localAddr net.UDPAddr
-	sendCh    chan netPayload
-	recvCh    chan netPayload
+	conn       *net.UDPConn
+	localAddr  net.UDPAddr
+	listenAddr net.UDPAddr
+	sendCh     chan netPayload
+	recvCh     chan netPayload
 
 	// shutdownCh will be closed on shutdown of the node
 	shutdownCh   chan struct{}
@@ -57,10 +58,15 @@ func NewNode(name string, style code.StyleCode, ip net.IP, log Logger, opts ...N
 			Name: name,
 			Type: style,
 		},
+		listenAddr:    net.UDPAddr{Port: packet.ArtNetPort},
 		broadcastAddr: defaultBroadcastAddr,
 		conn:          nil,
 		shutdown:      true,
 		log:           log.With(Fields{"type": "Node"}),
+	}
+
+	for _, opt := range opts {
+		n.SetOption(opt)
 	}
 
 	for _, opt := range opts {
@@ -85,6 +91,10 @@ func NewNode(name string, style code.StyleCode, ip net.IP, log Logger, opts ...N
 	}
 
 	return n
+}
+
+func (n *Node) Connection() *net.UDPConn {
+	return n.conn
 }
 
 // Stop will stop all running routines and close the network connection
@@ -117,7 +127,7 @@ func (n *Node) Start() error {
 	n.shutdownCh = make(chan struct{})
 	n.shutdown = false
 
-	c, err := net.ListenPacket("udp4", fmt.Sprintf(":%d", packet.ArtNetPort))
+	c, err := net.ListenPacket("udp4", n.listenAddr.String())
 	if err != nil {
 		n.shutdownErr = fmt.Errorf("error net.ListenPacket: %s", err)
 		n.log.With(Fields{"error": err}).Error("error net.ListenPacket")

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package artnet
 
-import "net"
+import (
+	"net"
+
+	"github.com/jsimonetti/go-artnet/packet"
+)
 
 // Option is a functional option handler for Controller.
 type Option func(*Controller) error
@@ -26,6 +30,22 @@ func BroadcastAddr(addr net.UDPAddr) Option {
 	}
 }
 
+// ListenAddr sets the listen address and port to use; defaults to :6454 if unset
+func ListenAddress(addr net.UDPAddr) Option {
+	return func(c *Controller) error {
+		NodeListenAddress(addr)(c.cNode)
+		return nil
+	}
+}
+
+// ListenIP sets the listen IP to use; defaults to :6454 if unset
+func ListenIP(ip net.IP) Option {
+	return func(c *Controller) error {
+		NodeListenIP(ip)(c.cNode)
+		return nil
+	}
+}
+
 // NodeOption is a functional option handler for Node.
 type NodeOption func(*Node) error
 
@@ -38,6 +58,22 @@ func (n *Node) SetOption(option NodeOption) error {
 func NodeBroadcastAddress(addr net.UDPAddr) NodeOption {
 	return func(n *Node) error {
 		n.broadcastAddr = addr
+		return nil
+	}
+}
+
+// NodeListenAddress sets the listen address and port to use; defaults to :6454 if unset
+func NodeListenAddress(addr net.UDPAddr) NodeOption {
+	return func(n *Node) error {
+		n.listenAddr = addr
+		return nil
+	}
+}
+
+// NodeListenIP sets the listen IP to use; defaults to :6454 if unset
+func NodeListenIP(ip net.IP) NodeOption {
+	return func(n *Node) error {
+		n.listenAddr = net.UDPAddr{IP: ip, Port: packet.ArtNetPort}
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package artnet
 
-import "net"
+import (
+	"net"
+
+	"github.com/jsimonetti/go-artnet/packet"
+)
 
 // Option is a functional option handler for Controller.
 type Option func(*Controller) error
@@ -26,6 +30,20 @@ func BroadcastAddr(addr net.UDPAddr) Option {
 	}
 }
 
+// ListenAddr sets the listen address and port to use; defaults to :6454 if unset
+func ListenAddress(addr net.UDPAddr) Option {
+	return func(c *Controller) error {
+		return NodeListenAddress(addr)(c.cNode)
+	}
+}
+
+// ListenIP sets the listen IP to use; defaults to :6454 if unset
+func ListenIP(ip net.IP) Option {
+	return func(c *Controller) error {
+		return NodeListenIP(ip)(c.cNode)
+	}
+}
+
 // NodeOption is a functional option handler for Node.
 type NodeOption func(*Node) error
 
@@ -38,6 +56,22 @@ func (n *Node) SetOption(option NodeOption) error {
 func NodeBroadcastAddress(addr net.UDPAddr) NodeOption {
 	return func(n *Node) error {
 		n.broadcastAddr = addr
+		return nil
+	}
+}
+
+// NodeListenAddress sets the listen address and port to use; defaults to :6454 if unset
+func NodeListenAddress(addr net.UDPAddr) NodeOption {
+	return func(n *Node) error {
+		n.listenAddr = addr
+		return nil
+	}
+}
+
+// NodeListenIP sets the listen IP to use; defaults to :6454 if unset
+func NodeListenIP(ip net.IP) NodeOption {
+	return func(n *Node) error {
+		n.listenAddr = net.UDPAddr{IP: ip, Port: packet.ArtNetPort}
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -1,5 +1,7 @@
 package artnet
 
+import "net"
+
 // Option is a functional option handler for Controller.
 type Option func(*Controller) error
 
@@ -12,6 +14,30 @@ func (c *Controller) SetOption(option Option) error {
 func MaxFPS(fps int) Option {
 	return func(c *Controller) error {
 		c.maxFPS = fps
+		return nil
+	}
+}
+
+// BroadcastAddr sets the broadcast address to use; defaults to 2.255.255.255:6454
+func BroadcastAddr(addr net.UDPAddr) Option {
+	return func(c *Controller) error {
+		c.broadcastAddr = addr
+		return nil
+	}
+}
+
+// NodeOption is a functional option handler for Node.
+type NodeOption func(*Node) error
+
+// SetOption runs a functional option against Node.
+func (n *Node) SetOption(option NodeOption) error {
+	return option(n)
+}
+
+// NodeBroadcastAddress sets the broadcast address to use; defaults to 2.255.255.255:6454
+func NodeBroadcastAddress(addr net.UDPAddr) NodeOption {
+	return func(n *Node) error {
+		n.broadcastAddr = addr
 		return nil
 	}
 }


### PR DESCRIPTION
This lets the caller set the IP and Port. Useful on multi-homed servers. 

This also exposes the udp connection on a Node, in case one wants to send a raw DMX packet, or otherwise. 